### PR TITLE
Rename mislabelled audio segments to .aac

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,7 @@ async fn index(req: HttpRequest) -> Result<HttpResponse, Box<dyn Error>> {
         QString::new(collected)
     };
 
-    let mut url = Url::parse(&format!("https://{}{}", host, req.path()))?;
+    let mut url = Url::parse(&format!("https://{}{}", host, req.path().replace("seg.aac", "seg.ts")))?;
     url.set_query(Some(qs.to_string().as_str()));
 
     let method = {
@@ -435,6 +435,8 @@ async fn index(req: HttpRequest) -> Result<HttpResponse, Box<dyn Error>> {
                                     utils::localize_url(url, host.as_str()).as_str(),
                                 );
                             }
+                        } else if line.contains("/itag/233") || line.contains("/itag/234") {
+                            return utils::localize_url(line.replace("seg.ts", "seg.aac").as_str(), host.as_str());
                         }
                         utils::localize_url(line, host.as_str())
                     })


### PR DESCRIPTION
Closes TeamPiped/Piped#2898

Since FireMasterK/NewPipeExtractor@8a9ebcc37316f859d9b5818b8d4eb192e4d811e1 InnerTube incorrectly provides AAC audio segments with a .ts extension and as shaka-player uses the file extension to choose which [transmuxer](https://github.com/shaka-project/shaka-player/tree/main/lib/transmuxer) to use these segments cause an error in their `TsTransmuxer`. By rewriting these segments to end in .aac (and then rewriting them back to .ts when we call InnerTube) they are correctly parsed by shaka-player's `AacTransmuxer`